### PR TITLE
登録画面のロジックを実装

### DIFF
--- a/src/app/hooks/useFetchRegisteredInfo.tsx
+++ b/src/app/hooks/useFetchRegisteredInfo.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+/**
+ * `useFetchRegisteredInfo`
+ *
+ * このフックは、ローカルストレージから登録情報を取得し、状態として保持します。
+ *
+ * @returns {object} - `registerdInfo` と `setRegisterdInfo` を含むオブジェクト
+ * @returns {Registertype} return.registerdInfo - 登録情報
+ * @returns {React.Dispatch<React.SetStateAction<Registertype>>} return.setRegisterdInfo - 登録情報を更新するための関数
+ */
+
+import { useState, useEffect } from "react";
+import { RegisterType } from "@/app/type";
+
+const useFetchRegisteredInfo = (): {
+  registeredInfo: RegisterType;
+  setRegisteredInfo: React.Dispatch<React.SetStateAction<RegisterType>>;
+} => {
+  const [registeredInfo, setRegisteredInfo] = useState<RegisterType>({
+    stream: undefined,
+    grade: undefined,
+    classNumber: undefined,
+  });
+
+  // SSRで初期化されないように、useEffectでローカルストレージから取得
+  useEffect(() => {
+    // 一度登録情報を取得したら、再度取得しない 無限ループを防ぐ
+    if (
+      registeredInfo.stream &&
+      registeredInfo.grade &&
+      registeredInfo.classNumber
+    ) {
+      return;
+    }
+
+    const _stream = localStorage.getItem("stream");
+    const _grade = localStorage.getItem("grade");
+    const _classNumber = localStorage.getItem("classNumber");
+
+    if (_stream && _grade && _classNumber) {
+      setRegisteredInfo({
+        stream: _stream,
+        grade: _grade,
+        classNumber: _classNumber,
+      });
+    }
+  }, [registeredInfo]);
+
+  return { registeredInfo, setRegisteredInfo };
+};
+
+export default useFetchRegisteredInfo;

--- a/src/app/register/RegisterPresenter.tsx
+++ b/src/app/register/RegisterPresenter.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { Select, Input } from "@headlessui/react";
+
+import { RegisterType } from "@/app/type";
+import { streamOptions, gradeOptions } from "./options";
+
+type RegisterPresenterProps = {
+  registeredInfo: RegisterType;
+  setRegisteredInfo: (info: RegisterType) => void;
+  isAutofillCompulsory: boolean;
+  setIsAutofillCompulsory: (isAutofillCompulsory: boolean) => void;
+};
+
+export default function RegisterPresenter({
+  registeredInfo,
+  setRegisteredInfo,
+  isAutofillCompulsory,
+  setIsAutofillCompulsory,
+}: RegisterPresenterProps) {
+  const { stream, grade, classNumber } = registeredInfo;
+
+  function StreamSelect() {
+    return (
+      <Select
+        name="stream"
+        id="compulsory"
+        value={stream}
+        onChange={(e) =>
+          setRegisteredInfo({ ...registeredInfo, stream: e.target.value })
+        }
+      >
+        {streamOptions.map((option) => {
+          return (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          );
+        })}
+      </Select>
+    );
+  }
+
+  function GradeSelect() {
+    return (
+      <Select
+        name="grade"
+        id="grade"
+        value={grade}
+        onChange={(e) =>
+          setRegisteredInfo({ ...registeredInfo, grade: e.target.value })
+        }
+      >
+        {gradeOptions.map((option) => {
+          return (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          );
+        })}
+      </Select>
+    );
+  }
+
+  function ClassNumberInput() {
+    return (
+      <Input
+        id="className-number"
+        type="number"
+        min="1"
+        max="39"
+        placeholder="組"
+        value={classNumber}
+        onChange={(e) => {
+          setRegisteredInfo({ ...registeredInfo, classNumber: e.target.value });
+        }}
+      />
+    );
+  }
+
+  function CompulsoryAutofillCheckbox() {
+    return (
+      <div>
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={isAutofillCompulsory}
+            onChange={(e) => setIsAutofillCompulsory(e.target.checked)}
+            className="h-4 w-4 rounded border bg-white checked:bg-blue-500 checked:border-transparent checked:text-white"
+          />
+          <span>必修を自動入力する</span>
+        </label>
+      </div>
+    );
+  }
+
+  return (
+    <div id="input-field">
+      <header id="input-message">所属入力</header>
+      <StreamSelect />
+      <GradeSelect />
+      <ClassNumberInput />
+      <CompulsoryAutofillCheckbox />
+      <button id="close-status" className="m-1 inline-flex">
+        OK
+      </button>
+    </div>
+  );
+}

--- a/src/app/register/options.ts
+++ b/src/app/register/options.ts
@@ -1,0 +1,45 @@
+export const streamOptions = [
+  {
+    value: "default",
+    label: "科類",
+  },
+  {
+    value: "l1",
+    label: "文科一類",
+  },
+  {
+    value: "l2",
+    label: "文科二類",
+  },
+  {
+    value: "l3",
+    label: "文科三類",
+  },
+  {
+    value: "s1",
+    label: "理科一類",
+  },
+  {
+    value: "s2",
+    label: "理科二類",
+  },
+  {
+    value: "s3",
+    label: "理科三類",
+  },
+];
+
+export const gradeOptions = [
+  {
+    value: "default",
+    label: "学年",
+  },
+  {
+    value: "1",
+    label: "1年",
+  },
+  {
+    value: "2",
+    label: "2年",
+  },
+];

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useState } from "react";
+
+import RegisterPresenter from "./RegisterPresenter";
+
+import useFetchRegisteredInfo from "@/app/hooks/useFetchRegisteredInfo";
+
+export default function RegisterContainer() {
+  const { registeredInfo, setRegisteredInfo } = useFetchRegisteredInfo();
+  const [isAutofillCompulsory, setIsAutofillCompulsory] =
+    useState<boolean>(true);
+  return (
+    <section>
+      <RegisterPresenter
+        registeredInfo={registeredInfo}
+        setRegisteredInfo={setRegisteredInfo}
+        isAutofillCompulsory={isAutofillCompulsory}
+        setIsAutofillCompulsory={setIsAutofillCompulsory}
+      />
+    </section>
+  );
+}

--- a/src/app/type.ts
+++ b/src/app/type.ts
@@ -9,4 +9,3 @@ export type RegisterType = {
   grade: string | undefined;
   classNumber: string | undefined;
 };
-

--- a/src/app/type.ts
+++ b/src/app/type.ts
@@ -1,0 +1,12 @@
+/**
+ * @typedef {RegisterType}
+ * @property {string | undefined} stream 科類
+ * @property {string | undefined} grade 学年
+ * @property {string | undefined} className 組
+ */
+export type RegisterType = {
+  stream: string | undefined;
+  grade: string | undefined;
+  classNumber: string | undefined;
+};
+


### PR DESCRIPTION
早めに共有したかったので、まだ完成していないですがPR出します

## やったこと
- 科類などの情報を登録する画面のロジックを実装
## 情報共有
- layout.tsがまだ決まっていないので、UIの実装は最低限しかしていない
- 科類・学年・クラスはアプリ全体で管理したいのでlayout.tsができ次第、useContextを使ってグローバルに管理するようにしたい